### PR TITLE
Fix UI Bug Sign-in page

### DIFF
--- a/src/layouts/auth/index.jsx
+++ b/src/layouts/auth/index.jsx
@@ -23,7 +23,7 @@ export default function Auth() {
         <FixedPlugin />
         <main className={`mx-auto min-h-screen`}>
           <div className="relative flex">
-            <div className="mx-auto flex min-h-full w-full flex-col justify-start pt-12 md:max-w-[75%] lg:h-screen lg:max-w-[1013px] lg:px-8 lg:pt-0 xl:h-[100vh] xl:max-w-[1383px] xl:px-0 xl:pl-[70px]">
+            <div className="mx-auto flex min-h-full w-full flex-col justify-start pt-12 md:max-w-[75%]  lg:max-w-[1013px] lg:px-8 lg:pt-0 xl:min-h-[100vh] xl:max-w-[1383px] xl:px-0 xl:pl-[70px]">
               <div className="mb-auto flex flex-col pl-5 pr-5 md:pr-0 md:pl-12 lg:max-w-[48%] lg:pl-0 xl:max-w-full">
                 <Link to="/admin" className="mt-0 w-max lg:pt-10">
                   <div className="mx-auto flex h-fit w-fit items-center hover:cursor-pointer">


### PR DESCRIPTION
Fix [UI Bug] Sign-in page white space #9 

For large-screen devices, website height is screen height, and that is the reason behind the bug.